### PR TITLE
Add option to disable admin endpoints

### DIFF
--- a/manager/api/api.ts
+++ b/manager/api/api.ts
@@ -19,7 +19,7 @@ import {
 import {config} from "../lib/config";
 import {createComputeAPI, instanceToGpuTypeAndCount, list, pause, remove, start} from "../gcp/resources";
 import {getTransport} from "../lib/client";
-import {catchErrors, enforceSetup, auth} from "./middleware";
+import {catchErrors, enforceSetup, auth, admin} from "./middleware";
 import {getAllModels} from "../lib/models";
 import {setupController} from "../controller/setup";
 import {chatCompletionController, completionController} from "../controller/generate";
@@ -275,9 +275,9 @@ export const haven = (router: ConnectRouter) =>
 		listWorkers: catchErrors(validate(listWorkersInputValid, auth(enforceSetup(listWorkers)))),
 
 		createInferenceWorker: catchErrors(
-			validate(createInferenceWorkerInputValid, auth(enforceSetup(createInferenceWorker))),
+			admin(validate(createInferenceWorkerInputValid, auth(enforceSetup(createInferenceWorker)))),
 		),
-		pauseInferenceWorker: catchErrors(validate(inferenceWorkerValid, auth(enforceSetup(pauseWorker)))),
-		resumeInferenceWorker: catchErrors(validate(inferenceWorkerValid, auth(enforceSetup(resumeWorker)))),
-		deleteInferenceWorker: catchErrors(validate(inferenceWorkerValid, auth(enforceSetup(deleteWorker)))),
+		pauseInferenceWorker: catchErrors(admin(validate(inferenceWorkerValid, auth(enforceSetup(pauseWorker))))),
+		resumeInferenceWorker: catchErrors(admin(validate(inferenceWorkerValid, auth(enforceSetup(resumeWorker))))),
+		deleteInferenceWorker: catchErrors(admin(validate(inferenceWorkerValid, auth(enforceSetup(deleteWorker))))),
 	});

--- a/manager/api/middleware.ts
+++ b/manager/api/middleware.ts
@@ -48,3 +48,16 @@ export function enforceSetup<T, U>(func: (req: T, context: HandlerContext) => U)
 		return func(req, context);
 	};
 }
+
+/**
+ * Check that admin endpoints are enabled and throw an error if not.
+ */
+export function admin<T, U>(func: (req: T, context: HandlerContext) => U) {
+	return (req: T, context: HandlerContext): U => {
+		if (config.server.disableAdmin) {
+			throw new ConnectError("Admin endpoints not enabled for this manager", Code.PermissionDenied);
+		}
+
+		return func(req, context);
+	};
+}

--- a/manager/lib/config.ts
+++ b/manager/lib/config.ts
@@ -3,6 +3,7 @@ const config = {
 	setupDone: false, // Tells us if the manager is in a working state
 	server: {
 		bearerToken: process.env.BEARER_TOKEN || "insecure",
+		disableAdmin: process.env.DISABLE_ADMIN === "true", // Disable admin endpoints
 	},
 	gcloud: {
 		projectId: "", // Set during setup


### PR DESCRIPTION
When setting the env variable `DISABLE_ADMIN` to true on the manager, you can't create, pause, resume or delete workers.