### PR TITLE
Allow custom worker images

### DIFF
--- a/manager/lib/config.ts
+++ b/manager/lib/config.ts
@@ -11,7 +11,7 @@ const config = {
 		clientId: "", // Set during setup
 	},
 	worker: {
-		dockerImage: "docker.io/havenhq/worker:v0.1",
+		dockerImage: process.env.CUSTOM_WORKER_IMAGE || "docker.io/havenhq/worker:v0.1",
 		startupScript: "./config/gcp/startup-script.sh",
 	},
 	telemetry: process.env.DISABLE_TELEMETRY !== "true",


### PR DESCRIPTION
Provide a value for the env variable `CUSTOM_WORKER_IMAGE` when creating the manager.