### PR TITLE
Turn list workers response into native python

### DIFF
--- a/sdk/havenpy/run.py
+++ b/sdk/havenpy/run.py
@@ -63,7 +63,22 @@ class Haven:
 	
 	def list_workers(self) -> manager_pb2.ListWorkersResponse:
 		request = manager_pb2.Empty()
-		return self.client.ListWorkers(request)
+		response = self.client.ListWorkers(request)
+
+		# Response is of a weird GRPC type, so we transform it to a list of dicts
+		# with worker_name and status as string attributes
+
+		workers = []
+		for worker in response.workers:
+			# Convert enum to string representation
+			status = manager_pb2.Status.Name(worker.status)
+
+			workers.append({
+				"worker_name": worker.worker_name,
+				"status": status
+			})
+
+		return workers
 	
 	def create_inference_worker(self, model_name: str, quantization: str, worker_name: str = None, gpu_type: manager_pb2.GpuType = None, gpu_count: int = None, zone: str = None) -> manager_pb2.InferenceWorker:
 		request = manager_pb2.CreateInferenceWorkerRequest(model_name=model_name, quantization=quantization, worker_name=worker_name, gpu_type=gpu_type, gpu_count=gpu_count, zone=zone)


### PR DESCRIPTION
We should really do something about the sdk. The python package we use to generate the grpc client code is really super wordy and not at all idiomatic.

This might be worth looking into:
https://github.com/danielgtaylor/python-betterproto